### PR TITLE
Fix case error in package.json main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-obfuscate",
   "version": "1.0.19",
   "description": "An intelligent React component to obfuscate any contact link",
-  "main": "dist/Obfuscate.js",
+  "main": "dist/obfuscate.js",
   "author": "Coston Perkins <coston.perkins@ua.edu> (http://coston.cool)",
   "homepage": "https://github.com/coston/react-obfuscate",
   "repository": {


### PR DESCRIPTION
React fails to compile since the main script is `dist/Obfuscate.js` in `package.json`, but the actual file is `dist/obfuscate.js`. 