### PR TITLE
Replace React.PropTypes with prop-types package

### DIFF
--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -13,6 +13,8 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -124,13 +126,13 @@ var Obfuscate = function (_Component) {
 }(_react.Component);
 
 Obfuscate.propTypes = {
-  children: _react.PropTypes.node,
-  tel: _react.PropTypes.string,
-  sms: _react.PropTypes.string,
-  facetime: _react.PropTypes.string,
-  email: _react.PropTypes.string,
-  headers: _react.PropTypes.object,
-  obfuscate: _react.PropTypes.bool
+  children: _propTypes.node,
+  tel: _propTypes.string,
+  sms: _propTypes.string,
+  facetime: _propTypes.string,
+  email: _propTypes.string,
+  headers: _propTypes.object,
+  obfuscate: _propTypes.bool
 };
 
 Obfuscate.defaultProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obfuscate",
-  "version": "1.0.0",
+  "version": "1.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1849,14 +1849,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1865,6 +1857,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^4.0.2",
     "core-js": "^2.4.1",
     "mocha": "^3.4.2",
+    "prop-types": "^15.5.10",
     "react": "^15.6.1",
     "react-addons-test-utils": "^15.6.0",
     "react-shallow-output": "^0.2.0"

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import {node, string, object, bool} from 'prop-types'
 
 export const combineHeaders = (searchParams = {}) => {
   return Object.keys(searchParams).map(key =>
@@ -63,13 +64,13 @@ class Obfuscate extends Component {
 }
 
 Obfuscate.propTypes = {
-  children: PropTypes.node,
-  tel: PropTypes.string,
-  sms: PropTypes.string,
-  facetime: PropTypes.string,
-  email: PropTypes.string,
-  headers: PropTypes.object,
-  obfuscate: PropTypes.bool
+  children: node,
+  tel: string,
+  sms: string,
+  facetime: string,
+  email: string,
+  headers: object,
+  obfuscate: bool
 }
 
 Obfuscate.defaultProps = {


### PR DESCRIPTION
React throws a deprecation warning, so use the new style instead.