### PR TITLE
Allow rendering of children content

### DIFF
--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -103,13 +103,21 @@ var Obfuscate = function (_Component) {
           children = _props2.children,
           others = _objectWithoutProperties(_props2, ['tel', 'sms', 'facetime', 'email', 'obfuscate', 'headers', 'children']);
 
+      var style = {
+        unicodeBidi: 'bidi-override'
+      };
+
+      if (!children) {
+        style.direction = 'rtl';
+      }
+
       return _react2.default.createElement(
         'a',
         _extends({
           onClick: this.handleClick.bind(this),
           href: 'obfuscated'
         }, others, {
-          style: { direction: 'rtl', unicodeBidi: 'bidi-override' }
+          style: style
         }),
         children || this.reverse(tel || sms || facetime || email).replace('(', ')').replace(')', '(')
       );

--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -104,9 +104,9 @@ var Obfuscate = function (_Component) {
           style = _props2.style,
           others = _objectWithoutProperties(_props2, ['tel', 'sms', 'facetime', 'email', 'obfuscate', 'headers', 'children', 'style']);
 
-      var obsStyle = {
+      var obsStyle = _extends({}, style || {}, {
         unicodeBidi: 'bidi-override'
-      };
+      });
 
       if (!children) {
         obsStyle.direction = 'rtl';

--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -101,14 +101,15 @@ var Obfuscate = function (_Component) {
           obfuscate = _props2.obfuscate,
           headers = _props2.headers,
           children = _props2.children,
-          others = _objectWithoutProperties(_props2, ['tel', 'sms', 'facetime', 'email', 'obfuscate', 'headers', 'children']);
+          style = _props2.style,
+          others = _objectWithoutProperties(_props2, ['tel', 'sms', 'facetime', 'email', 'obfuscate', 'headers', 'children', 'style']);
 
-      var style = {
+      var obsStyle = {
         unicodeBidi: 'bidi-override'
       };
 
       if (!children) {
-        style.direction = 'rtl';
+        obsStyle.direction = 'rtl';
       }
 
       return _react2.default.createElement(
@@ -117,7 +118,7 @@ var Obfuscate = function (_Component) {
           onClick: this.handleClick.bind(this),
           href: 'obfuscated'
         }, others, {
-          style: style
+          style: obsStyle
         }),
         children || this.reverse(tel || sms || facetime || email).replace('(', ')').replace(')', '(')
       );
@@ -147,7 +148,8 @@ Obfuscate.propTypes = {
   facetime: _propTypes.string,
   email: _propTypes.string,
   headers: _propTypes.object,
-  obfuscate: _propTypes.bool
+  obfuscate: _propTypes.bool,
+  style: _propTypes.object
 };
 
 Obfuscate.defaultProps = {

--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -82,7 +82,7 @@ var Obfuscate = function (_Component) {
         _extends({
           href: createContactLink(tel, sms, facetime, email, headers)
         }, others),
-        tel || sms || facetime || email || children
+        children || tel || sms || facetime || email
       );
     }
   }, {
@@ -111,7 +111,7 @@ var Obfuscate = function (_Component) {
         }, others, {
           style: { direction: 'rtl', unicodeBidi: 'bidi-override' }
         }),
-        this.reverse(tel || sms || facetime || email).replace('(', ')').replace(')', '(') || children
+        children || this.reverse(tel || sms || facetime || email).replace('(', ')').replace(')', '(')
       );
     }
   }, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obfuscate",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obfuscate",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "An intelligent React component to obfuscate any contact link",
   "main": "dist/obfuscate.js",
   "author": "Coston Perkins <coston.perkins@ua.edu> (https://coston.io)",

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -68,15 +68,16 @@ class Obfuscate extends Component {
       obfuscate,
       headers,
       children,
+      style,
       ...others
     } = this.props
 
-    const style = {
+    const obsStyle = {
       unicodeBidi: 'bidi-override',
     };
 
     if (!children) {
-      style.direction = 'rtl';
+      obsStyle.direction = 'rtl';
     }
 
     return (
@@ -84,7 +85,7 @@ class Obfuscate extends Component {
         onClick={this.handleClick.bind(this)}
         href="obfuscated"
         {...others}
-        style={style}
+        style={obsStyle}
       >
         {
           children ||
@@ -111,6 +112,7 @@ Obfuscate.propTypes = {
   email: string,
   headers: object,
   obfuscate: bool,
+  style: object,
 }
 
 Obfuscate.defaultProps = {

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -70,12 +70,21 @@ class Obfuscate extends Component {
       children,
       ...others
     } = this.props
+
+    const style = {
+      unicodeBidi: 'bidi-override',
+    };
+
+    if (!children) {
+      style.direction = 'rtl';
+    }
+
     return (
       <a
         onClick={this.handleClick.bind(this)}
         href="obfuscated"
         {...others}
-        style={{ direction: 'rtl', unicodeBidi: 'bidi-override' }}
+        style={style}
       >
         {
           children ||

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -47,7 +47,7 @@ class Obfuscate extends Component {
         href={createContactLink(tel, sms, facetime, email, headers)}
         {...others}
       >
-        {tel || sms || facetime || email || children}
+        {children || tel || sms || facetime || email}
       </a>
     )
   }
@@ -77,9 +77,12 @@ class Obfuscate extends Component {
         {...others}
         style={{ direction: 'rtl', unicodeBidi: 'bidi-override' }}
       >
-        {this.reverse(tel || sms || facetime || email)
-          .replace('(', ')')
-          .replace(')', '(') || children}
+        {
+          children ||
+          this.reverse(tel || sms || facetime || email)
+            .replace('(', ')')
+            .replace(')', '(')
+        }
       </a>
     )
   }

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -73,6 +73,7 @@ class Obfuscate extends Component {
     } = this.props
 
     const obsStyle = {
+      ...(style || {}),
       unicodeBidi: 'bidi-override',
     };
 


### PR DESCRIPTION
The way the code was working, if you supplied children content to your obfuscated link it never rendered. This PR allows content to be seen and styled. Basically, it was impossible to put text in your obfuscated link before this change.