### PR TITLE
Added onClick prop which is called prior to changing window.location

### DIFF
--- a/dist/obfuscate.js
+++ b/dist/obfuscate.js
@@ -86,7 +86,14 @@ function (_Component) {
   }, {
     key: "handleClick",
     value: function handleClick(event) {
-      event.preventDefault();
+      var onClick = this.props.onClick;
+      event.preventDefault(); // Allow instantiator to provide an onClick method to be called
+      // before we change location (e.g. for analytics tracking)
+
+      if (onClick && typeof onClick === 'function') {
+        onClick();
+      }
+
       window.location.href = this.createContactLink(this.props);
     }
   }, {
@@ -137,7 +144,7 @@ function (_Component) {
         onFocus: this.handleCopiability.bind(this),
         onMouseOver: this.handleCopiability.bind(this),
         onContextMenu: this.handleCopiability.bind(this)
-      }, clickProps, others, {
+      }, others, clickProps, {
         style: obsStyle
       });
 

--- a/readme.md
+++ b/readme.md
@@ -70,16 +70,17 @@ export default () => (
 
 ## Options
 
-| Prop      | Type        | Argument     | Default | Description                                             |
-| --------- | ----------- | ------------ | ------- | ------------------------------------------------------- |
-| email     | `string`    | `<optional>` | `null`  | email address of the intended recipient                 |
-| tel       | `string`    | `<optional>` | `null`  | telephone number of the intended recipient              |
-| sms       | `string`    | `<optional>` | `null`  | sms number of the intended recipient                    |
-| facetime  | `string`    | `<optional>` | `null`  | facetime address of the intended recipient              |
-| headers   | `object`    | `<optional>` | `null`  | subject, cc, bcc, body, etc                             |
-| obfuscate | `boolean`   | `<optional>` | `true`  | set to false to disable obfuscation                     |
-| linkText  | `string`    | `<optional>` | `obfuscated` | add custom obfuscated link text, like 'Email Me'   |
-| element | `string` | `<optional>` | `'a'`   | custom element to render instead of an `a` tag |
+| Prop      | Type        | Argument     | Default      | Description                                                    |
+| --------- | ----------- | ------------ | ------------ | -------------------------------------------------------------- |
+| email     | `string`    | `<optional>` | `null`       | email address of the intended recipient                        |
+| tel       | `string`    | `<optional>` | `null`       | telephone number of the intended recipient                     |
+| sms       | `string`    | `<optional>` | `null`       | sms number of the intended recipient                           |
+| facetime  | `string`    | `<optional>` | `null`       | facetime address of the intended recipient                     |
+| headers   | `object`    | `<optional>` | `null`       | subject, cc, bcc, body, etc                                    |
+| obfuscate | `boolean`   | `<optional>` | `true`       | set to false to disable obfuscation                            |
+| linkText  | `string`    | `<optional>` | `obfuscated` | add custom obfuscated link text, like 'Email Me'               |
+| element   | `string`    | `<optional>` | `'a'`        | custom element to render instead of an `a` tag                 |
+| onClick   | `function`  | `<optional>` | `null`       | called prior to setting location (e.g. for analytics tracking) |
 
 ## Development
 

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -40,7 +40,16 @@ export default class Obfuscate extends Component {
   }
 
   handleClick(event) {
+    const { onClick } = this.props
+
     event.preventDefault()
+
+    // Allow instantiator to provide an onClick method to be called
+    // before we change location (e.g. for analytics tracking)
+    if (onClick && typeof onClick === 'function') {
+      onClick()
+    }
+    
     window.location.href = this.createContactLink(this.props)
   }
 
@@ -104,8 +113,8 @@ export default class Obfuscate extends Component {
       onFocus: this.handleCopiability.bind(this),
       onMouseOver: this.handleCopiability.bind(this),
       onContextMenu: this.handleCopiability.bind(this),
-      ...clickProps,
       ...others,
+      ...clickProps,
       style: obsStyle,
     }
 

--- a/test/obfuscate.test.js
+++ b/test/obfuscate.test.js
@@ -1,49 +1,144 @@
 import React from 'react'
 import Obfuscate from '../src/obfuscate.js'
 
+const testEmail = 'coston.perkins@ua.edu'
+const testTel = '205-454-1234'
+const testTelReveresed = '4321-454-502'
+
+
 describe('obfuscate', () => {
+  beforeEach(() => {
+    delete global.window.location
+
+    global.window.location = {
+      href: new URL('https://example.com'),
+    }
+  })
+
   test('renders an ofuscated href', () => {
     const wrapper = shallow(
-      <Obfuscate tel='205-454-1234' />
+      <Obfuscate tel={testTel} />
     )
 
     expect(wrapper.prop('href')).toEqual('obfuscated')
   })
 
-  test('renders an unofuscated href when obfuscate prop equals false', () => {
+  test('properly sets location.href when ofuscated email is clicked', () => {
     const wrapper = shallow(
-      <Obfuscate obfuscate={false} sms='205-454-1234' />
+      <Obfuscate email={testEmail} />
     )
 
-    expect(wrapper.find('a').text()).toBe("205-454-1234")
-    expect(wrapper.prop('href')).toEqual('sms:205-454-1234')
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual(`mailto:${testEmail}`)
+  })
+
+  test('properly sets location.href when ofuscated email with headers is clicked', () => {
+    const headers = {
+      cc: 'dade@zero-cool.af',
+      bcc: 'smith@machina.net',
+      subject: 'react-obfuscate',
+      body: 'Down with the machines!'
+    }
+    const wrapper = shallow(
+      <Obfuscate email={testEmail} headers={headers} />
+    )
+
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual(`mailto:${testEmail}?${Object.keys(headers)
+      .map(key => `${key}=${encodeURIComponent(headers[key])}`)
+      .join('&')}`)
+  })
+
+  test('properly sets location.href when ofuscated tel is clicked', () => {
+    const wrapper = shallow(
+      <Obfuscate tel={testTel} />
+    )
+
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual(`tel:${testTel}`)
+  })
+
+  test('properly sets location.href when ofuscated sms is clicked', () => {
+    const wrapper = shallow(
+      <Obfuscate sms={testTel} />
+    )
+
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual(`sms:${testTel}`)
+  })
+
+  test('properly sets location.href when ofuscated facetime is clicked', () => {
+    const wrapper = shallow(
+      <Obfuscate facetime={testTel} />
+    )
+
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual(`facetime:${testTel}`)
+  })
+
+  test('properly sets location.href when ofuscated without type is clicked', () => {
+    const wrapper = shallow(
+      <Obfuscate>test</Obfuscate>
+    )
+
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(global.window.location.href).toEqual('test')
+  })
+
+  test('renders an unofuscated href when obfuscate prop equals false', () => {
+    const wrapper = shallow(
+      <Obfuscate obfuscate={false} sms={testTel} />
+    )
+
+    expect(wrapper.find('a').text()).toBe(testTel)
+    expect(wrapper.prop('href')).toEqual(`sms:${testTel}`)
   })
 
   test('renders an unofuscated child element left to right when obfuscate prop equals false', () => {
     const wrapper = shallow(
-      <Obfuscate obfuscate={false} facetime='205-454-1234' />
+      <Obfuscate obfuscate={false} facetime={testTel} />
     )
 
-    expect(wrapper.find('a').text()).toBe("205-454-1234")
-    expect(wrapper.prop('href')).toEqual('facetime:205-454-1234')
+    expect(wrapper.find('a').text()).toBe(testTel)
+    expect(wrapper.prop('href')).toEqual(`facetime:${testTel}`)
   })
 
   test('renders an unofuscated child element right to left when obfuscated', () => {
     const wrapper = shallow(
-      <Obfuscate obfuscate={true} tel='205-454-1234' />
+      <Obfuscate obfuscate={true} tel={testTel} />
     )
 
-    expect(wrapper.find('a').text()).toBe("4321-454-502")
+    expect(wrapper.find('a').text()).toBe(testTelReveresed)
     expect(wrapper.prop('href')).toEqual('obfuscated')
   })
 
   test('renders a custom element', () => {
     const wrapper = shallow(
-      <Obfuscate element="span" viewOnly tel='205-454-1234' />
+      <Obfuscate element="span" viewOnly tel={testTel} />
     )
 
-    expect(wrapper.find('span').text()).toBe("4321-454-502")
+    expect(wrapper.find('span').text()).toBe(testTelReveresed)
     expect(wrapper.prop('href')).toBeUndefined()
     expect(wrapper.prop('onClick')).toBeUndefined()
+  })
+
+  test('calls supplied onClick method before changing location', () => {
+    const onClick = jest.fn()
+    const wrapper = shallow(
+      <Obfuscate email={testEmail} onClick={onClick} />
+    )
+    
+    wrapper.simulate('click', { preventDefault: () => {} })
+    expect(onClick).toHaveBeenCalled()
+    expect(global.window.location.href).toEqual(`mailto:${testEmail}`)
+  })
+
+  test('unobfuscates href when user interacts with element', () => {
+    const wrapper = shallow(
+      <Obfuscate email={testEmail} />
+    )
+
+    wrapper.simulate('mouseover')
+    expect(wrapper.prop('href')).toEqual(`mailto:${testEmail}`)
   })
 })


### PR DESCRIPTION
This PR adds the ability to add a `onClick` prop to `<Obfuscate />` which is called prior to changing `window.location`.

This was needed for my specific use case of analytics tracking on links.

**Examle**
```html
<Obfuscate
  email="test@test.com"
  onClick={() => {
    console.log('this will be called before the "mailto:" link is followed')
  }}
/>
```

Also added some tests to achieve near 100% coverage.