### PR TITLE
Fix issue with linkText not being rendered as text child of links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-obfuscate",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "description": "An intelligent React component to obfuscate any contact link",
   "main": "dist/obfuscate.js",
   "files": [

--- a/src/obfuscate.js
+++ b/src/obfuscate.js
@@ -81,24 +81,26 @@ const Obfuscate = (props) => {
     typeof content !== 'undefined' &&
     content.split('').reverse().join('').replace('(', ')').replace(')', '(');
 
-  const obfuscatedStyle = {
-    ...style,
-    unicodeBidi: 'bidi-override',
-    direction:
-      humanInteraction === true ||
-      obfuscate === false ||
-      obfuscateChildren === false
-        ? 'ltr'
-        : 'rtl',
-  };
+  const obfuscatedStyle = linkText
+    ? style
+    : {
+        ...style,
+        unicodeBidi: 'bidi-override',
+        direction:
+          humanInteraction === true ||
+          obfuscate === false ||
+          obfuscateChildren === false
+            ? 'ltr'
+            : 'rtl',
+      };
 
   const renderedLink =
     humanInteraction === true ||
     obfuscate === false ||
     typeof children === 'object' ||
     obfuscateChildren === false // Allow child elements
-      ? linkProps
-      : reverse(linkProps);
+      ? linkText || linkProps
+      : linkText || reverse(linkProps);
 
   const clickProps =
     Component === 'a'
@@ -106,7 +108,7 @@ const Obfuscate = (props) => {
           href:
             humanInteraction === true || obfuscate === false
               ? generateLink()
-              : linkText || 'obfuscated',
+              : 'obfuscated',
           onClick: handleClick,
         }
       : {};

--- a/test/obfuscate.test.js
+++ b/test/obfuscate.test.js
@@ -7,6 +7,7 @@ const testEmail = 'coston.perkins@ua.edu';
 const testTel = '205-454-1234';
 const testTelReveresed = '4321-454-502';
 const originalLocation = 'https://example.com/';
+const testLinkText = 'Contact us';
 
 describe('obfuscate', () => {
   beforeEach(() => {
@@ -94,6 +95,18 @@ describe('obfuscate', () => {
 
     expect(wrapper.find('a').text()).toBe(testTel);
     expect(wrapper.prop('href')).toEqual(`facetime:${testTel}`);
+  });
+
+  test('renders the link text as a child when supplied', () => {
+    const wrapper = shallow(<Obfuscate email={testEmail} linkText={testLinkText} />);
+
+    expect(wrapper.find('a').text()).toBe(testLinkText);
+    expect(wrapper.prop('href')).toEqual('obfuscated');
+    expect(wrapper.find('a').prop('style')).toEqual({});
+
+    wrapper.simulate('mouseover');
+    expect(wrapper.find('a').text()).toBe(testLinkText);
+    expect(wrapper.prop('href')).toEqual(`mailto:${testEmail}`);
   });
 
   test('renders an unobfuscated child element right to left when obfuscated', () => {


### PR DESCRIPTION
## Description

This PR fixes an issue with react-obfuscate where the `linkText` prop wasn’t being rendered as a child of the `<a>` element. For example, with the following React:

```js
<p>
  <Obfuscate
    email="contact@darlow.uk"
    headers={{
      subject: 'So, I was on your website…',
    }}
    linkText="Get in touch"
  />{' '}
  to discuss your project requirements.
<p>
```

The `linkText` prop is ignored, and the email address supplied is still rendered. To fix this I’ve changed the `renderedLink` value to default to the `linkText` prop value, only falling back to the appropriate string if this prop is absent. Additionally, if `linkText` is set, the styles that visually reverse the obfuscated text are omitted, since this would otherwise erroneously reverse the provided text.

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/25730/86033366-be2c6b00-ba30-11ea-86ed-dfc8d99b2013.png)

After:

![image](https://user-images.githubusercontent.com/25730/86033477-e9af5580-ba30-11ea-86ca-633edabdfe8f.png)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- My code follows the code style of this project.
- If my change requires a change to the documentation I have updated the documentation accordingly.
